### PR TITLE
include both basic and projected workflows in dockstore

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -1,14 +1,14 @@
 version: 1.2
 workflows:
-  - subclass: WDL
-    name: projected_admixture
-    primaryDescriptorPath: projected_admixture.wdl
+  - name: projected_admixture
+    subclass: WDL
+    primaryDescriptorPath: /projected_admixture.wdl
     authors: 
       - orcid: 0000-0002-7989-5420
     testParameterFiles:
        - /projected_admixture.json
-    #  - subclass: WDL
-    #    name: basic_Admixture
-    #    primaryDescriptorPath: /basic_Admixture.wdl
-    #    authors:
-    #      - orcid: 0000-0002-7980-5420
+  - name: basic_admixture
+    subclass: WDL
+    primaryDescriptorPath: /basic_Admixture.wdl
+    authors:
+      - orcid: 0000-0002-7980-5420


### PR DESCRIPTION
Updated the .dockstore.yml file so both basic and projected workflows are available in dockstore