### PR TITLE
give workflows the same name in dockstore.yml and wdl files

### DIFF
--- a/basic_Admixture.wdl
+++ b/basic_Admixture.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-workflow Admixture {
+workflow basic_admixture {
   input {
     File bed
     File bim

--- a/projected_admixture.wdl
+++ b/projected_admixture.wdl
@@ -111,7 +111,7 @@ task run_admixture_projected {
 	}
 }
 
-workflow make_admixReady_projection_admixture_workflow {
+workflow projected_admixture {
 	input{
 		File P
 		File ref_bim


### PR DESCRIPTION
Workflows need to have the same name in .dockstore.yml and .wdl files